### PR TITLE
Remove documentation for non-existant flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@ Export nftables statistics to prometheus, original source from [https://github.c
 ### Command line options
 
 - `--config=/path/to/file.yaml`: Path to configuration file, default `/etc/nftables_exporter.yaml`
-- `--verbose`: verbosed log, default no
-- `--debug`: Debug logging, default no
 - `--version`: Show version and exit
 
 ### Configuration file


### PR DESCRIPTION
Remove documentation for non-existant flags (debug and verbose).

See #8 for details of how these flags are not implemented.