### PR TITLE
Add `nftables_up` metric

### DIFF
--- a/descriptions.go
+++ b/descriptions.go
@@ -3,6 +3,12 @@ package main
 import "github.com/prometheus/client_golang/prometheus"
 
 var (
+	upDesc = prometheus.NewDesc(
+		"nftables_up",
+		"'1' if reading the nft output was successful, '0' otherwise",
+		nil,
+		nil,
+	)
 	counterBytesDesc = prometheus.NewDesc(
 		"nftables_counter_bytes",
 		"Bytes, matched by counter",

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ type nftablesManagerCollector struct {
 
 // Describe sends the super-set of all possible descriptors of metrics
 func (i nftablesManagerCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- upDesc
 	ch <- counterBytesDesc
 	ch <- counterPacketsDesc
 	ch <- tableChainsDesc
@@ -32,7 +33,9 @@ func (i nftablesManagerCollector) Collect(ch chan<- prometheus.Metric) {
 	json, err := readData(i.opts)
 	if err != nil {
 		log.Printf("failed parsing nftables data: %s", err)
+		ch <- prometheus.MustNewConstMetric(upDesc, prometheus.GaugeValue, 0)
 	} else {
+		ch <- prometheus.MustNewConstMetric(upDesc, prometheus.GaugeValue, 1)
 		nft := newNFTables(json, ch)
 		nft.Collect()
 	}

--- a/readjson.go
+++ b/readjson.go
@@ -33,7 +33,7 @@ func readNFTables(opts options) (gjson.Result, error) {
 	nft := opts.Nft.NFTLocation
 	out, err := exec.Command(nft, "-j", "list", "ruleset").Output()
 	if err != nil {
-		log.Fatalf("nftables reading error: %s", err)
+		log.Printf("nftables reading error: %s", err)
 	}
 	return parseJSON(string(out))
 }


### PR DESCRIPTION
In case calling the nft binary fails this exporter exits immediatly. I think this is bad idea. This PR adds a new metcric `nftables_up` that indicates whether the call fo nftables worked. Similar exporters such as bind_exporter, chrony_exporter or impi_exporter use the same pattern.