### PR TITLE
Allow to configure log level, don't try to parse output of `nft` exited with non-zero status

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,13 @@ nftables_exporter:
   url_path: "/metrics"
   nft_location: /sbin/nft
   fake_nft_json: /path/to/nft.json
+  log_level: warn
 ```
 
 `fake_nft_json` used for debugging. I create this file with the command `nft -j list ruleset > /path/to/nft.json`. For normal exporter usage, this option is not needed.
+
+`log_level` can be one of the following: `debug`, `info`, `warn`, `error`.
+Default: `warn`.
 
 ## Example metrics
 

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"log/slog"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -55,5 +56,8 @@ func main() {
 		Addr:              opts.Nft.BindTo,
 		ReadHeaderTimeout: 1 * time.Minute,
 	}
+
+	// ListenAndServe always returns non-nil error
 	slog.Error("http server exited", "error", server.ListenAndServe().Error())
+	os.Exit(1)
 }

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"log/slog"
 	"net/http"
 	"os"
@@ -57,7 +58,10 @@ func main() {
 		ReadHeaderTimeout: 1 * time.Minute,
 	}
 
+	err := server.ListenAndServe()
 	// ListenAndServe always returns non-nil error
-	slog.Error("http server exited", "error", server.ListenAndServe().Error())
-	os.Exit(1)
+	if !errors.Is(err, http.ErrServerClosed) {
+		slog.Error("http server exited", "error", err)
+		os.Exit(1)
+	}
 }

--- a/nftables.go
+++ b/nftables.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -17,7 +17,7 @@ type nftables struct {
 
 // newNFTables is NFTables constructor
 func newNFTables(json gjson.Result, ch chan<- prometheus.Metric) nftables {
-	log.Print("collecting metrics")
+	slog.Debug("collecting metrics")
 	return nftables{
 		ch:   ch,
 		json: json,

--- a/options.go
+++ b/options.go
@@ -40,10 +40,10 @@ func loadOptions() options {
 	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
 		Level: logLevel,
 	})))
-	slog.Info(fmt.Sprintf("read options from %s\n", *configFile))
+	slog.Info("reading options from config file", "path", *configFile)
 	yamlFile, err := os.ReadFile(*configFile)
 	if err != nil {
-		slog.Error(fmt.Sprintf("failed read %s: %s", *configFile, err))
+		slog.Error("failed to read config file", "path", *configFile, "error", err)
 		os.Exit(1)
 	}
 
@@ -58,10 +58,10 @@ func loadOptions() options {
 	}
 
 	if yaml.Unmarshal(yamlFile, &opts) != nil {
-		slog.Error(fmt.Sprintf("failed parse %s: %s", *configFile, err))
+		slog.Error("failed to parse config file", "path", *configFile, "error", err)
 		os.Exit(1)
 	}
-	slog.Info(fmt.Sprintf("parsed options: %#v", opts))
+	slog.Info("parsed options", "opts", opts)
 	switch opts.Nft.LogLevel {
 	case "debug":
 		logLevel.Set(slog.LevelDebug)
@@ -72,7 +72,7 @@ func loadOptions() options {
 	case "error":
 		logLevel.Set(slog.LevelError)
 	default:
-		slog.Error(fmt.Sprintf("invalid log level %s. Allowed: debug,info,warn,error", opts.Nft.LogLevel))
+		slog.Error(fmt.Sprintf("invalid log level %s. allowed: debug,info,warn,error", opts.Nft.LogLevel))
 		os.Exit(1)
 	}
 

--- a/options.go
+++ b/options.go
@@ -60,13 +60,14 @@ func loadOptions() options {
 		slog.Error("failed to parse config file", "path", *configFile, "error", err)
 		os.Exit(1)
 	}
-	slog.Info("parsed options", "opts", opts)
 
 	err = logLevel.UnmarshalText([]byte(opts.Nft.LogLevel))
 	if err != nil {
 		slog.Error("cannot parse log level", "error", err)
 		os.Exit(1)
 	}
+
+	slog.Info("parsed options", "opts", opts)
 
 	return opts
 }

--- a/options.go
+++ b/options.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"flag"
-	"fmt"
 	"log"
 	"log/slog"
 	"os"
@@ -62,17 +61,10 @@ func loadOptions() options {
 		os.Exit(1)
 	}
 	slog.Info("parsed options", "opts", opts)
-	switch opts.Nft.LogLevel {
-	case "debug":
-		logLevel.Set(slog.LevelDebug)
-	case "info":
-		logLevel.Set(slog.LevelInfo)
-	case "warn":
-		logLevel.Set(slog.LevelWarn)
-	case "error":
-		logLevel.Set(slog.LevelError)
-	default:
-		slog.Error(fmt.Sprintf("invalid log level %s. allowed: debug,info,warn,error", opts.Nft.LogLevel))
+
+	err = logLevel.UnmarshalText([]byte(opts.Nft.LogLevel))
+	if err != nil {
+		slog.Error("cannot parse log level", "error", err)
 		os.Exit(1)
 	}
 

--- a/readjson.go
+++ b/readjson.go
@@ -13,7 +13,7 @@ import (
 // Parse json to gjson object
 func parseJSON(data string) (gjson.Result, error) {
 	if !gjson.Valid(data) {
-		return gjson.Parse("{}"), errors.New("invalid JSON")
+		return gjson.Result{}, errors.New("invalid JSON")
 	}
 	return gjson.Get(data, "nftables"), nil
 }
@@ -23,7 +23,7 @@ func readFakeNFTables(opts options) (gjson.Result, error) {
 	slog.Debug("read fake nftables data from json", "path", opts.Nft.FakeNftJSON)
 	jsonFile, err := os.ReadFile(opts.Nft.FakeNftJSON)
 	if err != nil {
-		return gjson.Parse("{}"), fmt.Errorf("fake nftables data reading error: %w", err)
+		return gjson.Result{}, fmt.Errorf("fake nftables data reading error: %w", err)
 	}
 	return parseJSON(string(jsonFile))
 }
@@ -34,7 +34,7 @@ func readNFTables(opts options) (gjson.Result, error) {
 	nft := opts.Nft.NFTLocation
 	out, err := exec.Command(nft, "-j", "list", "ruleset").Output()
 	if err != nil {
-		return gjson.Parse("{}"), fmt.Errorf("nftables reading error: %w", err)
+		return gjson.Result{}, fmt.Errorf("nftables reading error: %w", err)
 	}
 	return parseJSON(string(out))
 }

--- a/readjson.go
+++ b/readjson.go
@@ -2,7 +2,8 @@ package main
 
 import (
 	"errors"
-	"log"
+	"fmt"
+	"log/slog"
 	"os"
 	"os/exec"
 
@@ -19,21 +20,21 @@ func parseJSON(data string) (gjson.Result, error) {
 
 // Reading fake nftables json
 func readFakeNFTables(opts options) (gjson.Result, error) {
-	log.Printf("read fake nftables data from json: %s", opts.Nft.FakeNftJSON)
+	slog.Debug("read fake nftables data from json: %s", opts.Nft.FakeNftJSON)
 	jsonFile, err := os.ReadFile(opts.Nft.FakeNftJSON)
 	if err != nil {
-		log.Printf("fake nftables data reading error: %s", err)
+		return gjson.Parse("{}"), fmt.Errorf("fake nftables data reading error: %w", err)
 	}
 	return parseJSON(string(jsonFile))
 }
 
 // Get json from nftables and parse it
 func readNFTables(opts options) (gjson.Result, error) {
-	log.Print("collecting nftables counters...")
+	slog.Debug("collecting nftables counters...")
 	nft := opts.Nft.NFTLocation
 	out, err := exec.Command(nft, "-j", "list", "ruleset").Output()
 	if err != nil {
-		log.Printf("nftables reading error: %s", err)
+		return gjson.Parse("{}"), fmt.Errorf("nftables reading error: %w", err)
 	}
 	return parseJSON(string(out))
 }

--- a/readjson.go
+++ b/readjson.go
@@ -20,7 +20,7 @@ func parseJSON(data string) (gjson.Result, error) {
 
 // Reading fake nftables json
 func readFakeNFTables(opts options) (gjson.Result, error) {
-	slog.Debug("read fake nftables data from json: %s", opts.Nft.FakeNftJSON)
+	slog.Debug("read fake nftables data from json", "path", opts.Nft.FakeNftJSON)
 	jsonFile, err := os.ReadFile(opts.Nft.FakeNftJSON)
 	if err != nil {
 		return gjson.Parse("{}"), fmt.Errorf("fake nftables data reading error: %w", err)


### PR DESCRIPTION
## Description

Replace `log.Printf` everywhere with more precise `slog` calls, so that the user can optionally choose to enable verbose logging ("collecting metrics" message on every GET /metrics). (Fixes #28)

Also, if `nft -j list ruleset` fails, it now immediately returns an error instead of just writing a log message and trying to feed an empty string to the JSON parser.


