### PR TITLE
Bind to valid loopback address if no `bind_to` config option specified

### DIFF
--- a/options.go
+++ b/options.go
@@ -41,7 +41,7 @@ func loadOptions() options {
 
 	opts := options{
 		nftOptions{
-			BindTo:      "9630",
+			BindTo:      "127.0.0.1:9630",
 			URLPath:     "/metrics",
 			FakeNftJSON: "",
 			NFTLocation: "/sbin/nft",

--- a/options.go
+++ b/options.go
@@ -41,7 +41,7 @@ func loadOptions() options {
 
 	opts := options{
 		nftOptions{
-			BindTo:      "127.0.0.1:9630",
+			BindTo:      ":9630",
 			URLPath:     "/metrics",
 			FakeNftJSON: "",
 			NFTLocation: "/sbin/nft",


### PR DESCRIPTION
## Description

Just noticed that the default value of `bind_to` is missing an address.

(I make it point to `127.0.0.1`, so the user must explicitly bind it to listen all hosts)

### Reproduction

**nftables_exporter.yaml**
```sh
nftables_exporter:
  nft_location: /sbin/nft
```

On `master`:
```sh
$ nftables-exporter --config ./nftables_exporter.yaml

{"time":"2025-02-05T15:28:22.343308942+03:00","level":"INFO","msg":"read options from ./nftables_exporter.yaml"}
{"time":"2025-02-05T15:28:22.343433469+03:00","level":"INFO","msg":"parsed options: main.options{Nft:main.nftOptions{BindTo:\"9630\", URLPath:\"/metrics\", FakeNftJSON:\"\", NFTLocation:\"/sbin/nft\"}}"}
{"time":"2025-02-05T15:28:22.343571337+03:00","level":"INFO","msg":"starting on 9630/metrics"}
{"time":"2025-02-05T15:28:22.34360088+03:00","level":"INFO","msg":"listen tcp: address 9630: missing port in address"}
```

On this PR:
```sh
$ ./nftables-exporter --config ./nftables_exporter.yaml

{"time":"2025-02-05T15:28:59.543653416+03:00","level":"INFO","msg":"read options from ./nftables_exporter.yaml"}
{"time":"2025-02-05T15:28:59.543793239+03:00","level":"INFO","msg":"parsed options: main.options{Nft:main.nftOptions{BindTo:\"127.0.0.1:9630\", URLPath:\"/metrics\", FakeNftJSON:\"\", NFTLocation:\"/sbin/nft\"}}"}
{"time":"2025-02-05T15:28:59.544001646+03:00","level":"INFO","msg":"starting on 127.0.0.1:9630/metrics"}
```

