### PR TITLE
Always use terse mode when listing nftables ruleset

### DIFF
--- a/readjson.go
+++ b/readjson.go
@@ -31,8 +31,7 @@ func readFakeNFTables(opts options) (gjson.Result, error) {
 // Get json from nftables and parse it
 func readNFTables(opts options) (gjson.Result, error) {
 	slog.Debug("collecting nftables counters...")
-	nft := opts.Nft.NFTLocation
-	out, err := exec.Command(nft, "-j", "list", "ruleset").Output()
+	out, err := exec.Command(opts.Nft.NFTLocation, "-j", "-t", "list", "ruleset").Output()
 	if err != nil {
 		return gjson.Result{}, fmt.Errorf("nftables reading error: %w", err)
 	}


### PR DESCRIPTION
## Problem

`nft list ruleset` serializes all set and map elements on every scrape. On rulesets with large sets (e.g. GeoIP maps with hundreds of thousands of CIDR→mark entries), this takes 20+ seconds per scrape, causing concurrent `nft` processes to pile up and max out CPU.

## Fix

Pass `-t` (`--terse`) to `nft list ruleset`, which omits set/map element output. This is unconditional because the exporter never reads set or map elements — it only processes `table`, `chain`, `rule`, and `counter` objects — so there is no scenario where element output is useful.

## Testing

Verified on a router with a ~700k-line GeoIP nftables ruleset. Before: `nft list ruleset` took >20s and spawned pileup processes consuming ~1.5GB RAM each. After: scrapes complete in milliseconds. Metric output is identical (confirmed by diffing `/metrics` before and after).